### PR TITLE
MTC-11167 Remove bugged company segment filter logic from company tags bundle

### DIFF
--- a/Controller/CompanyController.php
+++ b/Controller/CompanyController.php
@@ -90,9 +90,6 @@ class CompanyController extends CompanyControllerBase
         if (str_contains($search, 'tag:')) {
             $filter     = $this->filterByCompanyTag($search);
         }
-        if (str_contains($search, 'company-segment:')) {
-            $filter     = $this->filterByCompanySegment($search);
-        }
 
         $orderBy    = $request->getSession()->get('mautic.company.orderby', 'comp.companyname');
         $orderByDir = $request->getSession()->get('mautic.company.orderbydir', 'ASC');
@@ -177,44 +174,6 @@ class CompanyController extends CompanyControllerBase
         }
 
         $companiesIds = $this->companyTagModel->getCompaniesIdByTags([$tag->getId()]);
-
-        return [
-            'force' => [
-                [
-                    'column' => 'comp.id',
-                    'expr'   => 'in',
-                    'value'  => $companiesIds,
-                ],
-            ],
-        ];
-    }
-
-    /**
-     * @return mixed[][]
-     */
-    private function filterByCompanySegment(string $search): array
-    {
-        $defaultFilter        = ['string' => 'Invalid company segment', 'force' => []];
-        $companySegmentSearch = str_replace('company-segment:', '', $search);
-        $companySegmentSearch = str_replace('"', '', $companySegmentSearch);
-        if (!class_exists(\MauticPlugin\LeuchtfeuerCompanySegmentsBundle\Entity\CompanySegment::class)) {
-            return $defaultFilter;
-        }
-        $companySegmentResult = $this
-            ->getModel(\MauticPlugin\LeuchtfeuerCompanySegmentsBundle\Model\CompanySegmentModel::class)
-            ->getRepository()->findOneBy(['alias' => $companySegmentSearch]);
-
-        if (!$companySegmentResult) {
-            return ['string' => 'Invalid company segment', 'force' => []];
-        }
-        foreach ($companySegmentResult->getCompaniesSegments() as $companySegmentResult) {
-            assert($companySegmentResult instanceof \MauticPlugin\LeuchtfeuerCompanySegmentsBundle\Entity\CompaniesSegments);
-            $companiesIds[$companySegmentResult->getCompany()->getId()] = $companySegmentResult->getCompany()->getId();
-        }
-
-        if (empty($companiesIds)) {
-            return $defaultFilter;
-        }
 
         return [
             'force' => [

--- a/Tests/Functional/Controller/CompanyControllerTest.php
+++ b/Tests/Functional/Controller/CompanyControllerTest.php
@@ -271,18 +271,4 @@ class CompanyControllerTest extends MauticMysqlTestCase
         $this->client->request('GET', '/s/company/view/'.$company->getId());
         $this->assertStringContainsString('LeuchtfeuerCompanyTagsBundle/Assets/js/companyTag.js', $this->client->getResponse()->getContent());
     }
-
-    public function testSearchCompanySegment()
-    {
-        $company = $this->registerCompany('Test Company Segment', 'test@test.com');
-        $this->client->request('GET', '/s/companies?search=company-segment:comp-seg-2-companies');
-        $this->assertResponseStatusCodeSame(200);
-    }
-
-    public function testSearchCompanySegmentNoColumn()
-    {
-        $company = $this->registerCompany('Test Company Segment', 'test@test.com');
-        $this->client->request('GET', '/s/companies?search=compan:comp-seg-2-companies');
-        $this->assertResponseStatusCodeSame(200);
-    }
 }

--- a/Tests/Unit/Entity/CompanyTagTest.php
+++ b/Tests/Unit/Entity/CompanyTagTest.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace MauticPlugin\LeuchtfeuerCompanyTagsBundle\Tests\Unit\Entity;
-
-class CompanyTagTest extends \PHPUnit\Framework\TestCase
-{
-}


### PR DESCRIPTION
This PR removes bugged company segment filter logic from the company tags bundle. Company segment filter will still work as the proper logic is implemented in the CompanySegmentsBundle